### PR TITLE
Showcase the use of my logger POC in http4s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ import scala.xml.transform.{RewriteRule, RuleTransformer}
 
 // Global settings
 ThisBuild / crossScalaVersions := Seq(scala_3, scala_212, scala_213)
+ThisBuild / scalaVersion := scala_213
 ThisBuild / tlBspCrossProjectPlatforms := Set(JVMPlatform)
 ThisBuild / tlBaseVersion := "0.23"
 ThisBuild / developers += tlGitHubDev("rossabaker", "Ross A. Baker")
@@ -470,6 +471,7 @@ lazy val emberCore = libraryCrossProject("ember-core", CrossType.Full)
     startYear := Some(2019),
     unusedCompileDependenciesFilter -= moduleFilter("io.chrisdavenport", "log4cats-core"),
     libraryDependencies ++= Seq(
+      "io.github.baccata" %% "logger-kernel" % "0.1.0-SNAPSHOT",
       log4catsCore.value,
       log4catsTesting.value % Test,
       log4catsNoop.value % Test,
@@ -606,6 +608,9 @@ lazy val emberServer = libraryCrossProject("ember-server")
   .settings(
     description := "ember implementation for http4s servers",
     startYear := Some(2019),
+    libraryDependencies ++= Seq(
+      "io.github.baccata" %% "logger-log4cats" % "0.1.0-SNAPSHOT"
+    ),
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.http4s.ember.server.EmberServerBuilder#Defaults.maxConcurrency"
@@ -656,7 +661,8 @@ lazy val emberClient = libraryCrossProject("ember-client")
     description := "ember implementation for http4s clients",
     startYear := Some(2019),
     libraryDependencies ++= Seq(
-      keypool.value
+      keypool.value,
+      "io.github.baccata" %% "logger-log4cats" % "0.1.0-SNAPSHOT",
     ),
     mimaBinaryIssueFilters := Seq(
       ProblemFilters

--- a/ember-client/jvm/src/main/scala/org/http4s/ember/client/EmberClientBuilderCompanionPlatform.scala
+++ b/ember-client/jvm/src/main/scala/org/http4s/ember/client/EmberClientBuilderCompanionPlatform.scala
@@ -18,8 +18,8 @@ package org.http4s.ember.client
 
 import cats.effect.Async
 import fs2.io.net.unixsocket.UnixSockets
-import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import logger.LoggerKernel
 
 private[client] trait EmberClientBuilderPlatform {
 
@@ -30,6 +30,7 @@ private[client] trait EmberClientBuilderPlatform {
 
 private[client] trait EmberClientBuilderCompanionPlatform {
 
-  private[client] def defaultLogger[F[_]: Async]: Logger[F] = Slf4jLogger.getLogger[F]
+  private[client] def defaultLogger[F[_]: Async]: LoggerKernel[F] =
+    logger.interoplog4cats.log4catsBackend(Slf4jLogger.getLogger[F])
 
 }


### PR DESCRIPTION
The goal is to showcase that we can change the logging interface expected by Ember without breaking existing users, as long as there exists a lossless interop layer 

* all the internals switch to the new interface
* new builder methods taking the new interface are created in EmberServerBuilder/EmberClientBuilder
* old builder methods taking the log4cats interface remain, but their implementation wrap the provided logger into the new interface for the internals 

This is built on top of a publish-local of https://github.com/Baccata/logger-poc/